### PR TITLE
Fixed win32ax include path

### DIFF
--- a/main.asm
+++ b/main.asm
@@ -88,7 +88,7 @@
 
     format PE GUI 6.0
     entry initialize
-    include '\fasm\include\win32ax.inc'
+    include 'include\win32ax.inc'
 
 macro init_dll dll_id, dll_name, [func_name]
 {


### PR DESCRIPTION
When you download Flat Assembler from its official website and extract the zip, the directory hierarchy is such that **win32ax.inc** is found directly under the include directory under the newly created main folder, where FASM.exe is found.
Thus the change enables to use the assembler just like the README advises, (simply by running `fasm main.asm`) without any further changes needed - neither to the fasm command-line args, the directory hierarchy, nor the .asm source file.